### PR TITLE
[COOK-29] Drag and Drop Sections

### DIFF
--- a/src/components/GuideDetailView/GuideDetailView.tsx
+++ b/src/components/GuideDetailView/GuideDetailView.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from "react";
+import React, { FunctionComponent, useState, ReactElement } from "react";
 
 /* Components */
 import {
@@ -10,6 +10,10 @@ import {
   EuiFieldText,
   EuiAvatar,
   EuiButtonIcon,
+  EuiDragDropContext,
+  EuiDroppable,
+  EuiDraggable,
+  euiDragDropReorder,
 } from "@elastic/eui";
 
 /* Styles */
@@ -20,10 +24,7 @@ import { Guide } from "../../models/Guide";
 
 export interface GuideDetailViewProps {}
 
-export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = () => {
-  const [editing, setEditing] = useState<boolean>(false);
-  const [collapsed, setCollapsed] = useState<Object>({});
-
+export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = (): ReactElement => {
   const mockGuide = {
     _id: "mock_id",
     title: "falco",
@@ -59,7 +60,9 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = () => {
     ],
     tags: [],
   };
-
+  const [editing, setEditing] = useState<boolean>(false);
+  const [collapsed, setCollapsed] = useState<Array<boolean>>([]);
+  const [sections, setSections] = useState<any>(mockGuide.sections);
   const [guide, setGuide] = useState<Guide | null>(mockGuide);
 
   const buildSideNaveItems = () => {
@@ -89,27 +92,45 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = () => {
   };
 
   const handleCancel = () => {
+    setSections([...mockGuide.sections]);
     setGuide({ ...mockGuide });
+    setCollapsed([]);
     setEditing(false);
   };
 
   const handleSave = () => {
+    setCollapsed([]);
     setEditing(false);
   };
 
   const handleCollapse = (index) => {
     collapsed[index] = collapsed[index] ? !collapsed[index] : true;
-    setCollapsed({ ...collapsed });
+    setCollapsed([...collapsed]);
+  };
+
+  const handleDragEnd = (result) => {
+    const { source, destination } = result;
+
+    if (source && destination) {
+      const items = euiDragDropReorder(
+        sections,
+        source.index,
+        destination.index
+      );
+      setCollapsed([
+        ...euiDragDropReorder(collapsed, source.index, destination.index),
+      ]);
+      setSections([...items]);
+    }
   };
 
   const buildSections = () => {
-    if (!guide) return;
+    if (!guide) return [<></>];
 
-    return guide.sections.map((section, index) => {
+    return sections.map((section, index) => {
       const { title, body } = section;
       const isCollapsed = collapsed[index] && collapsed[index] === true;
-
-      return (
+      const sectionPanel = (
         <EuiPanel
           id={section.title}
           hasShadow={false}
@@ -153,6 +174,20 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = () => {
             </div>
           )}
         </EuiPanel>
+      );
+
+      return editing ? (
+        <EuiDraggable
+          spacing="m"
+          key={index}
+          index={index}
+          draggableId={index.toString()}
+          isDragDisabled={!editing}
+        >
+          {sectionPanel}
+        </EuiDraggable>
+      ) : (
+        sectionPanel
       );
     });
   };
@@ -221,7 +256,19 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = () => {
               />
             </EuiPanel>
             <div id="sections" className="guide-content__sections">
-              {buildSections()}
+              {editing ? (
+                <EuiDragDropContext onDragEnd={handleDragEnd}>
+                  <EuiDroppable
+                    droppableId="DROPPABLE_AREA"
+                    spacing="m"
+                    className="guide-content__droppable"
+                  >
+                    {buildSections()}
+                  </EuiDroppable>
+                </EuiDragDropContext>
+              ) : (
+                buildSections()
+              )}
             </div>
             <div className="guide-content__right"></div>
           </div>

--- a/src/components/GuideDetailView/GuideDetailView.tsx
+++ b/src/components/GuideDetailView/GuideDetailView.tsx
@@ -196,7 +196,10 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = (): Reac
     <div id="guide-detail" className="guide-detail">
       {guide && (
         <>
-          <div className="guide-detail__controls">
+          <div
+            className="guide-detail__controls"
+            style={editing ? { paddingRight: 8 } : {}}
+          >
             {editing ? (
               <>
                 <EuiButton
@@ -232,6 +235,7 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = (): Reac
           <div className="guide-detail__content">
             <EuiPanel
               className="guide-content__side-nav"
+              style={editing ? { marginTop: 8 } : {}}
               hasShadow={false}
               hasBorder
             >

--- a/src/components/GuideDetailView/GuideDetailView.tsx
+++ b/src/components/GuideDetailView/GuideDetailView.tsx
@@ -67,7 +67,7 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = (): Reac
 
   const buildSideNaveItems = () => {
     if (!guide) return;
-    return guide.sections.map((section, index) => {
+    return sections.map((section, index) => {
       const { title } = section;
       return {
         name: title,

--- a/src/components/GuideDetailView/GuideDetailView.tsx
+++ b/src/components/GuideDetailView/GuideDetailView.tsx
@@ -9,6 +9,7 @@ import {
   EuiButton,
   EuiFieldText,
   EuiAvatar,
+  EuiButtonIcon,
 } from "@elastic/eui";
 
 /* Styles */
@@ -21,6 +22,7 @@ export interface GuideDetailViewProps {}
 
 export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = () => {
   const [editing, setEditing] = useState<boolean>(false);
+  const [collapsed, setCollapsed] = useState<Object>({});
 
   const mockGuide = {
     _id: "mock_id",
@@ -95,11 +97,17 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = () => {
     setEditing(false);
   };
 
+  const handleCollapse = (index) => {
+    collapsed[index] = collapsed[index] ? !collapsed[index] : true;
+    setCollapsed({ ...collapsed });
+  };
+
   const buildSections = () => {
     if (!guide) return;
 
     return guide.sections.map((section, index) => {
       const { title, body } = section;
+      const isCollapsed = collapsed[index] && collapsed[index] === true;
 
       return (
         <EuiPanel
@@ -107,32 +115,42 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = () => {
           hasShadow={false}
           hasBorder
           className="guide-section"
+          key={index}
         >
-          {editing ? (
-            <>
+          <div className="guide-section__title">
+            {editing ? (
               <EuiFieldText
-                className="guide-section__title-input"
                 placeholder="title"
                 value={title}
                 onChange={(e) => updateSection("title", e.target.value, index)}
               />
-              <EuiMarkdownEditor
-                className="guide-section__body-input"
-                aria-label="Body markdown editor"
-                value={body}
-                onChange={(value) => updateSection("body", value, index)}
-                height={400}
-              />
-            </>
-          ) : (
-            <>
-              <div className="guide-section__title">
-                <EuiMarkdownFormat>{`# **\#** **${title}** \n---`}</EuiMarkdownFormat>
-              </div>
-              <div className="guide-section__body">
+            ) : (
+              <div>{title}</div>
+            )}
+            <EuiButtonIcon
+              aria-label="collapse-icon"
+              iconType={isCollapsed ? "arrowDown" : "arrowUp"}
+              iconSize="l"
+              size="m"
+              className="guide-section__title--collapse"
+              onClick={() => {
+                handleCollapse(index);
+              }}
+            ></EuiButtonIcon>
+          </div>
+          {!isCollapsed && (
+            <div className="guide-section__body">
+              {editing ? (
+                <EuiMarkdownEditor
+                  aria-label="Body markdown editor"
+                  value={body}
+                  onChange={(value) => updateSection("body", value, index)}
+                  height={400}
+                />
+              ) : (
                 <EuiMarkdownFormat>{body}</EuiMarkdownFormat>
-              </div>
-            </>
+              )}
+            </div>
           )}
         </EuiPanel>
       );

--- a/src/components/GuideDetailView/_guide-detail-view.scss
+++ b/src/components/GuideDetailView/_guide-detail-view.scss
@@ -1,4 +1,6 @@
 @import "../../styles/responsive";
+@import "@elastic/eui/src/themes/eui-amsterdam/eui_amsterdam_colors_dark.scss";
+@import "@elastic/eui/src/themes/eui-amsterdam/eui_amsterdam_globals.scss";
 
 #guide-detail {
   padding: 24px 24px 0 24px;
@@ -61,17 +63,35 @@
         height: 100%;
         overflow: auto;
 
+        .euiPanel {
+          flex-grow: 0;
+
+          &--paddingMedium {
+            padding: 0;
+          }
+        }
+
         .guide-section {
           width: 100%;
           margin-bottom: 14px;
 
-          &__body-input {
-            margin-top: 12px;
+          &__title {
+            display: flex;
+            align-items: center;
+            padding: 8px 16px;
+            background-color: lighten($color: $euiColorEmptyShade, $amount: 5%);
+            font-size: 24px;
+            font-weight: bold;
+            text-transform: capitalize;
+            border-bottom: 1px solid $euiColorLightShade;
+
+            &--collapse {
+              margin-left: auto;
+            }
           }
 
           &__body {
-            margin-top: 12px;
-            padding: 0 12px;
+            padding: 16px;
           }
         }
       }

--- a/src/components/GuideDetailView/_guide-detail-view.scss
+++ b/src/components/GuideDetailView/_guide-detail-view.scss
@@ -54,6 +54,10 @@
         }
       }
 
+      &__droppable {
+        width: 100%;
+      }
+
       &__sections {
         display: flex;
         flex-direction: column;

--- a/src/components/GuideDetailView/_guide-detail-view.scss
+++ b/src/components/GuideDetailView/_guide-detail-view.scss
@@ -78,7 +78,7 @@
             display: flex;
             align-items: center;
             padding: 8px 16px;
-            background-color: lighten($color: $euiColorEmptyShade, $amount: 5%);
+            background-color: lighten($color: $euiColorEmptyShade, $amount: 4%);
             font-size: 24px;
             font-weight: bold;
             text-transform: capitalize;

--- a/src/components/GuideDetailView/_guide-detail-view.scss
+++ b/src/components/GuideDetailView/_guide-detail-view.scss
@@ -1,6 +1,5 @@
 @import "../../styles/responsive";
 @import "@elastic/eui/src/themes/eui-amsterdam/eui_amsterdam_colors_dark.scss";
-@import "@elastic/eui/src/themes/eui-amsterdam/eui_amsterdam_globals.scss";
 
 #guide-detail {
   padding: 24px 24px 0 24px;

--- a/src/components/GuideDetailView/_guide-detail-view.scss
+++ b/src/components/GuideDetailView/_guide-detail-view.scss
@@ -38,7 +38,6 @@
         max-width: 248px;
         margin-right: 24px;
         margin-left: -272px;
-        transition: margin 200ms;
 
         @include respond-to(gt-sm) {
           margin-left: 0;

--- a/src/components/GuideDetailView/_guide-detail-view.scss
+++ b/src/components/GuideDetailView/_guide-detail-view.scss
@@ -80,7 +80,7 @@
             padding: 8px 16px;
             background-color: lighten($color: $euiColorEmptyShade, $amount: 4%);
             font-size: 24px;
-            font-weight: bold;
+            font-weight: 600;
             text-transform: capitalize;
             border-bottom: 1px solid $euiColorLightShade;
 


### PR DESCRIPTION
## Description

Sections can now be re-ordered by dragging and dropping in edit mode. (Make sure to do the collapsed section PR first since this is technically blocked by that)

# [COOK-29](https://cdekalb.atlassian.net/browse/COOK-29)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] in edit mode you can drag and drop to re-order
- [x] dragging and dropping respects collapsed sections
- [x] all sections expand when saved or canceled
- [x] side nav respects re-order