### PR TITLE
[COOK-28] Add section button

### DIFF
--- a/src/components/GuideDetailView/GuideDetailView.tsx
+++ b/src/components/GuideDetailView/GuideDetailView.tsx
@@ -18,6 +18,10 @@ import "./_guide-detail-view.scss";
 
 /* Types */
 import { Guide } from "../../models/Guide";
+import { Tag } from "../../models/Tag";
+
+/* Constants */
+import { newSection } from "../../constants/constants";
 
 export interface GuideDetailViewProps {}
 
@@ -25,7 +29,7 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = () => {
   const [editing, setEditing] = useState<boolean>(false);
   const [collapsed, setCollapsed] = useState<Object>({});
 
-  const mockGuide = {
+  const mockGuide: Guide = {
     _id: "mock_id",
     title: "falco",
     sections: [
@@ -34,7 +38,7 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = () => {
         title: "basics",
         body: `The first key to understanding how to fight falco is that both of his primary walling options (bair and utilt) have virtually the exact same range. Meaning, if you're spacing for one you're simultaneously spacing for the other. This makes it far simpler to smother him/punish him
 \n![](https://media.giphy.com/media/ZpLzabCMomHUQPbcvg/giphy.gif) ![](https://media.giphy.com/media/ZpLzabCMomHUQPbcvg/giphy.gif) ![](https://media.giphy.com/media/ZpLzabCMomHUQPbcvg/giphy.gif)`,
-        tags: [],
+        tags: Array<Tag>(),
       },
       {
         _id: "mock_post_id",
@@ -49,16 +53,16 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = () => {
 * \`~65%\` Uthrow regrab
 * \`~65%\` Uthrow dash SH uair
 * \`~105%\` Uthrow dash SH knee`,
-        tags: [],
+        tags: Array<Tag>(),
       },
       {
         _id: "mock_post_id",
         title: "defense-and-recovery",
-        body: `![](https://media.giphy.com/media/ZpLzabCMomHUQPbcvg/giphy.gif) ![](https://media.giphy.com/media/ZpLzabCMomHUQPbcvg/giphy.gif) ![](https://media.giphy.com/media/ZpLzabCMomHUQPbcvg/giphy.gif)`,
-        tags: [],
+        body: `![](https://media.giphy.com/media/ZpLzabCMomHUQPbcvg/giphy.gif) ![](https://media.giphy.com/media/ZpLzabCMomHUQPbcvg/giphy.gif) ![](https://media.giphy.com/media/ZpLzabCMomHUQPbcvg/giphy.gif) `,
+        tags: Array<Tag>(),
       },
     ],
-    tags: [],
+    tags: Array<Tag>(),
   };
 
   const [guide, setGuide] = useState<Guide | null>(mockGuide);
@@ -89,6 +93,13 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = () => {
     setGuide({ ...guide });
   };
 
+  const addSection = () => {
+    if (!guide) return;
+    const { sections } = guide;
+    sections.unshift(newSection);
+    setGuide({ ...guide });
+  };
+
   const handleCancel = () => {
     setGuide({ ...mockGuide });
     setEditing(false);
@@ -96,6 +107,9 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = () => {
 
   const handleSave = () => {
     setEditing(false);
+    if (!guide) return;
+    mockGuide.sections = guide.sections;
+    console.log(mockGuide.sections);
   };
 
   const handleCollapse = (index) => {
@@ -165,6 +179,15 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = () => {
           <div className="guide-detail__controls">
             {editing ? (
               <>
+                <EuiButton
+                  className="guide-controls__button"
+                  fill
+                  iconType="plus"
+                  color="primary"
+                  onClick={addSection}
+                >
+                  Add
+                </EuiButton>
                 <EuiButton
                   className="guide-controls__button"
                   fill

--- a/src/components/GuideDetailView/GuideDetailView.tsx
+++ b/src/components/GuideDetailView/GuideDetailView.tsx
@@ -109,7 +109,6 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = () => {
     setEditing(false);
     if (!guide) return;
     mockGuide.sections = guide.sections;
-    console.log(mockGuide.sections);
   };
 
   const handleCollapse = (index) => {

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -9,3 +9,21 @@ env.base_url = isLocal ? "http://localhost:3000" : "http://localhost:3000";
 env.isLocal = isLocal;
 
 export const ENV = env;
+
+import { Post } from "../models/Post";
+import { Tag } from "../models/Tag";
+
+const sampleBody = `
+ ## gfycat template 
+    must start with 'thumbs' and end with '-size_restricted.gif'
+    ![](https://thumbs.gfycat.com/FlakyExaltedHairstreak-size_restricted.gif) 
+ ## gif template 
+    ![](https://media.giphy.com/media/ZpLzabCMomHUQPbcvg/giphy.gif) 
+ `;
+
+export const newSection: Post = {
+  _id: "mock_post_id",
+  title: "**replace with title",
+  body: sampleBody,
+  tags: Array<Tag>(),
+};

--- a/src/models/Post.ts
+++ b/src/models/Post.ts
@@ -1,5 +1,6 @@
 import { Tag } from "./Tag";
 export interface Post {
+  _id: string;
   title: string;
   body: string;
   tags: Array<Tag>;


### PR DESCRIPTION
## Description

added an add section button to the GuideDetailView

## Issues to address
- Even after *saving* the view, pressing cancel while in edit mode will replace the view with the original mock data

# [COOK-28](https://cdekalb.atlassian.net/browse/COOK-28)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] Add button appears after clicking `edit`
- [ ] Clicking `add` button adds new template post to the view
- [ ] Pressing `save` keeps the new post in the view
