### PR TITLE
[COOK-51] Fix a Bug with Adding and Re-Ordering

### DIFF
--- a/src/components/GuideDetailView/GuideDetailView.tsx
+++ b/src/components/GuideDetailView/GuideDetailView.tsx
@@ -1,4 +1,9 @@
-import React, { FunctionComponent, useState, ReactElement } from "react";
+import React, {
+  FunctionComponent,
+  useState,
+  useEffect,
+  ReactElement,
+} from "react";
 
 /* Components */
 import {
@@ -66,9 +71,17 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = (): Reac
     tags: Array<Tag>(),
   };
   const [editing, setEditing] = useState<boolean>(false);
-  const [collapsed, setCollapsed] = useState<Array<boolean>>([]);
-  const [sections, setSections] = useState<any>(mockGuide.sections);
+  const [collapsed, setCollapsed] = useState<Array<boolean>>(
+    Array(mockGuide.sections.length).fill(false)
+  );
+  const [sections, setSections] = useState<any>();
   const [guide, setGuide] = useState<Guide | null>(mockGuide);
+
+  useEffect(() => {
+    if (guide) {
+      setSections(guide.sections);
+    }
+  }, [guide]);
 
   const buildSideNaveItems = () => {
     if (!guide) return;
@@ -99,19 +112,21 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = (): Reac
   const addSection = () => {
     if (!guide) return;
     const { sections } = guide;
-    sections.unshift(newSection);
+    sections.unshift({ ...newSection });
+    collapsed.unshift(false);
+    setCollapsed([...collapsed]);
     setGuide({ ...guide });
   };
 
   const handleCancel = () => {
     setSections([...mockGuide.sections]);
     setGuide({ ...mockGuide });
-    setCollapsed([]);
+    setCollapsed(Array(mockGuide.sections.length).fill(false));
     setEditing(false);
   };
 
   const handleSave = () => {
-    setCollapsed([]);
+    setCollapsed(Array(mockGuide.sections.length).fill(false));
     setEditing(false);
     if (!guide) return;
     mockGuide.sections = guide.sections;
@@ -147,7 +162,7 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = (): Reac
 
       const sectionPanel = (
         <EuiPanel
-          id={section.title}
+          id={`section-${index}`}
           hasShadow={false}
           hasBorder
           className="guide-section"
@@ -209,7 +224,7 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> = (): Reac
 
   return (
     <div id="guide-detail" className="guide-detail">
-      {guide && (
+      {guide && sections && (
         <>
           <div
             className="guide-detail__controls"


### PR DESCRIPTION
COOK-51

## Description

Fixed a bug where you couldnt add after re-ordering and adding would mess up the collapsed sections. Also fixes an issue where if you added more than one post, editing one also edited the other.

# [COOK-51](https://cdekalb.atlassian.net/browse/COOK-51)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] You can add more than one section and editing one does not affect the other
- [x] You can re-order and then add a section
- [x] re-ordering/adding sections respects being collapsed or not
