### PR TITLE
[COOK-135] collapse all sections

### DIFF
--- a/src/components/GuideDetailView/GuideDetailHeader/GuideDetailHeader.tsx
+++ b/src/components/GuideDetailView/GuideDetailHeader/GuideDetailHeader.tsx
@@ -26,18 +26,24 @@ export interface GuideDetailHeaderProps {
   character: string | null;
   showControls: boolean;
   sections: Array<Post>;
+  allCollapsed: boolean;
   handleCancel: () => void;
   handleSave: () => void;
   handleAddSection: () => void;
   handleSetEditing: (isEditing: boolean) => void;
+  handleCollapseAll: () => void;
+  handleExpandAll: () => void;
 }
 
 export const GuideDetailHeader: FunctionComponent<GuideDetailHeaderProps> = ({
   editing,
+  allCollapsed,
   handleCancel,
   handleAddSection,
   handleSave,
   handleSetEditing,
+  handleCollapseAll,
+  handleExpandAll,
   title,
   character,
   sections,
@@ -107,52 +113,75 @@ export const GuideDetailHeader: FunctionComponent<GuideDetailHeaderProps> = ({
           <p>{title}</p>
         </EuiTitle>
       </div>
-      {editing ? (
-        <div className="guide-header__controls">
+      <div className="guide-header__controls">
+        {allCollapsed ? (
           <EuiButtonIcon
-            aria-label="cancel"
+            aria-label="expand all"
             className="guide-header__controls__button"
             display="fill"
-            iconType="cross"
-            color="danger"
-            onClick={handleCancel}
+            iconType="arrowDown"
             size="m"
             iconSize="l"
+            onClick={handleExpandAll}
           />
+        ) : (
           <EuiButtonIcon
-            aria-label="save"
+            aria-label="collapse all"
             className="guide-header__controls__button"
             display="fill"
-            iconType="save"
-            color="success"
-            onClick={handleSave}
+            iconType="arrowUp"
             size="m"
             iconSize="l"
+            onClick={handleCollapseAll}
           />
-          <EuiButtonIcon
-            aria-label="add"
-            className="guide-header__controls__button"
-            display="fill"
-            iconType="plus"
-            color="success"
-            onClick={handleAddSection}
-            size="m"
-            iconSize="l"
-          />
-        </div>
-      ) : (
-        showControls && (
-          <EuiButtonIcon
-            aria-label="edit"
-            className="guide-header__controls__edit"
-            display="fill"
-            iconType="pencil"
-            size="m"
-            iconSize="l"
-            onClick={() => handleSetEditing(!editing)}
-          />
-        )
-      )}
+        )}
+        {editing ? (
+          <>
+            <EuiButtonIcon
+              aria-label="cancel"
+              className="guide-header__controls__button"
+              display="fill"
+              iconType="cross"
+              color="danger"
+              onClick={handleCancel}
+              size="m"
+              iconSize="l"
+            />
+            <EuiButtonIcon
+              aria-label="save"
+              className="guide-header__controls__button"
+              display="fill"
+              iconType="save"
+              color="success"
+              onClick={handleSave}
+              size="m"
+              iconSize="l"
+            />
+            <EuiButtonIcon
+              aria-label="add"
+              className="guide-header__controls__button"
+              display="fill"
+              iconType="plus"
+              color="success"
+              onClick={handleAddSection}
+              size="m"
+              iconSize="l"
+            />
+          </>
+        ) : (
+          showControls && (
+            <EuiButtonIcon
+              aria-label="edit"
+              className="guide-header__controls__edit"
+              display="fill"
+              iconType="pencil"
+              size="m"
+              iconSize="l"
+              onClick={() => handleSetEditing(!editing)}
+            />
+          )
+        )}
+      </div>
       {flyoutVis && flyout()}
     </div>
   );

--- a/src/components/GuideDetailView/GuideDetailView.tsx
+++ b/src/components/GuideDetailView/GuideDetailView.tsx
@@ -43,6 +43,7 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> =
     const [collapsed, setCollapsed] = useState<Array<boolean>>(
       Array<boolean>(),
     );
+    const [allCollapsed, setAllCollapsed] = useState(false);
     const [guide, setGuide] = useState<Guide | null>(null);
     const [state] = useContext(Context);
     const { cookbook, user } = state;
@@ -56,10 +57,15 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> =
         slug: guideSlug.toLowerCase(),
       });
       setGuide(guide[0]);
+      return guide[0];
     };
 
     useEffect(() => {
-      getGuide();
+      const init = async () => {
+        const setterGuide = await getGuide();
+        setCollapsed(Array(setterGuide.sections.length).fill(false));
+      };
+      init();
     }, []);
 
     const updateSection = (key, value, index) => {
@@ -83,8 +89,18 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> =
 
     const handleCancel = async () => {
       await getGuide();
-      setCollapsed(Array(guide?.sections.length).fill(false));
+      handleExpandAll();
       setEditing(false);
+    };
+
+    const handleExpandAll = () => {
+      setCollapsed(Array(guide?.sections.length).fill(false));
+      setAllCollapsed(false);
+    };
+
+    const handleCollapseAll = () => {
+      setCollapsed(Array(guide?.sections.length).fill(true));
+      setAllCollapsed(true);
     };
 
     const handleDelete = (index) => {
@@ -113,7 +129,7 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> =
           },
         );
         toast.successToast('Guide saved!', 'Guide saved');
-        setCollapsed(Array(guide.sections.length).fill(false));
+        handleExpandAll();
         await getGuide();
         setEditing(false);
       } catch (error) {
@@ -173,6 +189,7 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> =
           </EuiDraggable>
         ) : (
           <GuideDetailSection
+            key={index}
             title={title}
             body={body}
             index={index}
@@ -198,10 +215,13 @@ export const GuideDetailView: FunctionComponent<GuideDetailViewProps> =
               >
                 <GuideDetailHeader
                   editing={editing}
+                  allCollapsed={allCollapsed}
                   handleCancel={handleCancel}
                   handleSave={handleSave}
                   handleAddSection={handleAddSection}
                   handleSetEditing={handleSetEditing}
+                  handleCollapseAll={handleCollapseAll}
+                  handleExpandAll={handleExpandAll}
                   sections={guide.sections}
                   title={guide.title}
                   character={guide.character}


### PR DESCRIPTION
## Description

adds a button to collapse and expand all sections in a guide

# [COOK-135](https://cdekalb.atlassian.net/browse/COOK-135)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] collapse all
- [ ] expand all
