### PR TITLE
Fix Twitch sidebar input box overflow

### DIFF
--- a/src/components/TwitchSidebar/_twitch-sidebar.scss
+++ b/src/components/TwitchSidebar/_twitch-sidebar.scss
@@ -3,7 +3,6 @@
 
 .twitch-sidebar {
   height: calc(100% - 54px);
-  overflow: hidden;
   width: 254px;
   padding-left: 24px;
   display: flex;


### PR DESCRIPTION
## Description

Removes `overflow:hidden` from twitch sidebar to stop bottom of new stream input being hidden

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] 👀 
